### PR TITLE
add argument passing

### DIFF
--- a/rofi-systemd
+++ b/rofi-systemd
@@ -1,7 +1,5 @@
 #!/usr/bin/env sh
 
-echo "$@"
-
 term=${ROFI_SYSTEMD_TERM-urxvt -e}
 default_action=${ROFI_SYSTEMD_DEFAULT_ACTION-"list_actions"}
 rofi_command=${ROFI_SYSTEMD_ROFI_COMMAND-"rofi $@ -dmenu -i -p"}

--- a/rofi-systemd
+++ b/rofi-systemd
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
+echo "$@"
+
 term=${ROFI_SYSTEMD_TERM-urxvt -e}
 default_action=${ROFI_SYSTEMD_DEFAULT_ACTION-"list_actions"}
-rofi_command=${ROFI_SYSTEMD_ROFI_COMMAND-"rofi -dmenu -i -p"}
+rofi_command=${ROFI_SYSTEMD_ROFI_COMMAND-"rofi $@ -dmenu -i -p"}
 truncate_length=${ROFI_SYSTEMD_TRUNCATE_LENGTH-60}
 files_jquery_columns=${ROFI_SYSTEMD_FILES_JQ_COLUMNS-'(.[0] + " " + .[1])'}
 running_jquery_columns=${ROFI_SYSTEMD_RUNNING_JQ_COLUMNS-'(.[0] + " " + .[3])'}


### PR DESCRIPTION
command-line args to rofi-systemd will be passed on to rofi, e.g.
rofi-systemd -theme "~/.config/rofi/dark.rasi"
is parsed as
`rofi_command=${ROFI_SYSTEMD_ROFI_COMMAND-"rofi -theme \"~/.config/rofi/dark.rasi\" -dmenu -i -p"}`