### PR TITLE
Add a keyboard shortcut for unit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ to a different action, i.e. one of:
  - enable
  - disable
  - stop
+ - status
  - restart
  - tail
+ - boot_logs
  - list_actions
 
 ## Keybindings
@@ -32,5 +34,7 @@ You can trigger an action other than the default action by using the following k
  - enable="Alt+e"
  - disable="Alt+d"
  - stop="Alt+k"
+ - status="Alt+s"
  - restart="Alt+r"
  - tail="Alt+t"
+ - boot_logs="Alt+l"

--- a/rofi-systemd
+++ b/rofi-systemd
@@ -54,6 +54,7 @@ all_units() {
 enable="Alt+e"
 disable="Alt+d"
 stop="Alt+k"
+status="Alt+s"
 restart="Alt+r"
 tail="Alt+t"
 boot_logs="Alt+l"
@@ -72,9 +73,10 @@ select_service_and_act() {
 	              -kb-custom-1 "${enable}" \
 	              -kb-custom-2 "${disable}" \
 	              -kb-custom-3 "${stop}" \
-	              -kb-custom-4 "${restart}" \
-	              -kb-custom-5 "${tail}" \
-				  -kb-custom-6 "${boot_logs}")
+	              -kb-custom-4 "${status}" \
+	              -kb-custom-5 "${restart}" \
+	              -kb-custom-6 "${tail}" \
+				  -kb-custom-7 "${boot_logs}")
 
 	rofi_exit="$?"
 
@@ -93,15 +95,18 @@ select_service_and_act() {
 			action="stop"
 			;;
 		13)
-			action="restart"
+			action="status"
 			;;
 		14)
-			action="tail"
+			action="restart"
 			;;
 		15)
-			action="boot_logs"
+			action="tail"
 			;;
 		16)
+			action="boot_logs"
+			;;
+		17)
 			action="list_actions"
 			;;
 		*)


### PR DESCRIPTION
## Summary
- add an `Alt+s` shortcut for the existing `status` action
- shift the remaining custom-key mappings so `restart`, `tail`, and `boot_logs` still work
- document the available actions and shortcuts in the README

## Validation
- sh -n rofi-systemd